### PR TITLE
fix: cache Prisma client on global in production to fix connection po…

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -43,14 +43,13 @@ const datasourceUrl = withConnectionLimit(process.env.DATABASE_URL, poolSize)
 export const prisma: PrismaClient = global.prismaGlobal ?? new PrismaClient({
   log: ['warn', 'error'],
   datasources: datasourceUrl ? { db: { url: datasourceUrl } } : undefined,
-  // Add transaction timeout
   transactionOptions: {
-    timeout: 30000, // 30 seconds
+    timeout: 30000,
   },
 })
 
-if (process.env.NODE_ENV !== 'production') {
-  global.prismaGlobal = prisma
-}
+// Cache on global in all environments so serverless reuses one client per worker.
+// Without this, production created a new PrismaClient per request → connection pool exhaustion.
+global.prismaGlobal = prisma
 
 


### PR DESCRIPTION
…ol timeout

Reuse single PrismaClient per serverless worker; previously production never set global.prismaGlobal so each request created a new client and exhausted the connection pool (connection limit: 1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prisma client lifecycle/caching behavior in production; mistakes could lead to stale connections or unexpected sharing, but the change is small and localized.
> 
> **Overview**
> Ensures `PrismaClient` is always cached on `global.prismaGlobal`, including production/serverless, so requests reuse a single client per worker instead of creating a new client per request and exhausting the DB connection pool.
> 
> Minor cleanup in `src/lib/prisma.ts` includes tightening the transaction timeout config (no behavioral change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2244cce1a5d3ccf4c7803bfb14b6bad27d4cb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->